### PR TITLE
wip version 3

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,60 @@
+# Clojure CircleCI 2.0 configuration file
+#
+# Check https://circleci.com/docs/2.0/language-clojure/ for more details
+#
+version: 2.1
+jobs:
+  jvm:
+    docker:
+      # specify the version you desire here
+      - image: circleci/clojure:lein-2.8.1
+    working_directory: ~/repo
+    environment:
+      LEIN_ROOT: "true"
+      BABASHKA_PLATFORM: linux # could be used in jar name
+    resource_class: large
+    steps:
+      - checkout
+      - restore_cache:
+          keys:
+            - v1-dependencies-{{ checksum "project.clj" }}
+            # fallback to using the latest cache if no exact match is found
+            - v1-dependencies-
+      - run:
+          name: Install Clojure
+          command: |
+            wget -nc https://download.clojure.org/install/linux-install-1.10.1.447.sh
+            chmod +x linux-install-1.10.1.447.sh
+            sudo ./linux-install-1.10.1.447.sh
+
+  deploy:
+    resource_class: large
+    docker:
+      - image: circleci/clojure:lein-2.8.1
+    working_directory: ~/repo
+    environment:
+      LEIN_ROOT: "true"
+    steps:
+      - checkout
+      - restore_cache:
+          keys:
+          - v1-dependencies-{{ checksum "project.clj" }}
+          # fallback to using the latest cache if no exact match is found
+          - v1-dependencies-
+      - run: .circleci/script/deploy
+      - save_cache:
+          paths:
+            - ~/.m2
+          key: v1-dependencies-{{ checksum "project.clj" }}
+
+workflows:
+  version: 2
+  ci:
+    jobs:
+      - jvm
+      - deploy:
+          filters:
+            branches:
+              only: master
+          requires:
+            - jvm

--- a/.circleci/script/deploy
+++ b/.circleci/script/deploy
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+
+if [ -z "$CIRCLE_PULL_REQUEST" ] && [ "$CIRCLE_BRANCH" = "master" ]
+then
+    lein deploy clojars
+fi
+
+exit 0;

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject babashka/clojure-lanterna "0.9.7"
+(defproject babashka/clojure-lanterna "0.9.8-SNAPSHOT"
   :description "A Clojure wrapper around the Lanterna terminal output library."
   :url "https://github.com/babashka/clojure-lanterna"
   :license {:name "LGPL"}

--- a/project.clj
+++ b/project.clj
@@ -1,12 +1,11 @@
-(defproject clojure-lanterna "0.9.7"
+(defproject babashka/clojure-lanterna "0.9.7"
   :description "A Clojure wrapper around the Lanterna terminal output library."
-  :url "http://multimud.github.io/clojure-lanterna/"
+  :url "https://github.com/babashka/clojure-lanterna"
   :license {:name "LGPL"}
-  :dependencies [[org.clojure/clojure "1.4.0"]
-                 [com.googlecode.lanterna/lanterna "2.1.7"]]
+  :dependencies [[com.googlecode.lanterna/lanterna "3.0.3"]]
   :java-source-paths ["./java"]
-  ; :repositories {"sonatype-snapshots" "https://oss.sonatype.org/content/repositories/snapshots"}
+  :profiles {:dev {:dependencies [[org.clojure/clojure "1.10.2-alpha1"]]}}
   :repositories {"releases" {:url "https://clojars.org/repo"
-                             :username :env
-                             :password :env
+                             :username :env/babashka_nrepl_clojars_user
+                             :password :env/babashka_nrepl_clojars_pass
                              :sign-releases false}})

--- a/src/lanterna/common.clj
+++ b/src/lanterna/common.clj
@@ -1,9 +1,9 @@
 (ns lanterna.common
-  (:import com.googlecode.lanterna.input.Key)
+  (:import com.googlecode.lanterna.input.KeyType)
   (:require [lanterna.constants :as c]))
 
 
-(defn parse-key [^Key k]
+(defn parse-key [^KeyType k]
   (when k
     (let [kind (c/key-codes (.getKind k))]
       (if (= kind :normal)

--- a/src/lanterna/constants.clj
+++ b/src/lanterna/constants.clj
@@ -1,72 +1,69 @@
 (ns lanterna.constants
   (:import java.nio.charset.Charset
-           com.googlecode.lanterna.TerminalFacade
-           com.googlecode.lanterna.screen.Screen
-           com.googlecode.lanterna.terminal.Terminal
-           com.googlecode.lanterna.screen.ScreenCharacterStyle
-           com.googlecode.lanterna.terminal.swing.TerminalPalette
-           com.googlecode.lanterna.input.Key))
-
+           com.googlecode.lanterna.input.KeyType
+           com.googlecode.lanterna.TextColor$ANSI
+           com.googlecode.lanterna.SGR
+           ;; com.googlecode.lanterna.terminal.swing.TerminalPalette
+           ))
 
 (def charsets {:utf-8 (Charset/forName "UTF-8")})
 
 (def colors
-  {:black   com.googlecode.lanterna.terminal.Terminal$Color/BLACK
-   :white   com.googlecode.lanterna.terminal.Terminal$Color/WHITE
-   :red     com.googlecode.lanterna.terminal.Terminal$Color/RED
-   :green   com.googlecode.lanterna.terminal.Terminal$Color/GREEN
-   :blue    com.googlecode.lanterna.terminal.Terminal$Color/BLUE
-   :cyan    com.googlecode.lanterna.terminal.Terminal$Color/CYAN
-   :magenta com.googlecode.lanterna.terminal.Terminal$Color/MAGENTA
-   :yellow  com.googlecode.lanterna.terminal.Terminal$Color/YELLOW
-   :default com.googlecode.lanterna.terminal.Terminal$Color/DEFAULT})
+  {:black   TextColor$ANSI/BLACK
+   :white   TextColor$ANSI/WHITE
+   :red     TextColor$ANSI/RED
+   :green   TextColor$ANSI/GREEN
+   :blue    TextColor$ANSI/BLUE
+   :cyan    TextColor$ANSI/CYAN
+   :magenta TextColor$ANSI/MAGENTA
+   :yellow  TextColor$ANSI/YELLOW
+   :default TextColor$ANSI/DEFAULT})
 
 (def styles
-  {:bold ScreenCharacterStyle/Bold
-   :reverse ScreenCharacterStyle/Reverse
-   :underline ScreenCharacterStyle/Underline
-   :blinking ScreenCharacterStyle/Blinking})
+  {:bold SGR/BOLD
+   :reverse SGR/REVERSE
+   :underline SGR/UNDERLINE
+   :blinking SGR/BLINK})
 
 (def key-codes
-  {com.googlecode.lanterna.input.Key$Kind/NormalKey :normal
-   com.googlecode.lanterna.input.Key$Kind/Escape :escape
-   com.googlecode.lanterna.input.Key$Kind/Backspace :backspace
-   com.googlecode.lanterna.input.Key$Kind/ArrowLeft :left
-   com.googlecode.lanterna.input.Key$Kind/ArrowRight :right
-   com.googlecode.lanterna.input.Key$Kind/ArrowUp :up
-   com.googlecode.lanterna.input.Key$Kind/ArrowDown :down
-   com.googlecode.lanterna.input.Key$Kind/Insert :insert
-   com.googlecode.lanterna.input.Key$Kind/Delete :delete
-   com.googlecode.lanterna.input.Key$Kind/Home :home
-   com.googlecode.lanterna.input.Key$Kind/End :end
-   com.googlecode.lanterna.input.Key$Kind/PageUp :page-up
-   com.googlecode.lanterna.input.Key$Kind/PageDown :page-down
-   com.googlecode.lanterna.input.Key$Kind/Tab :tab
-   com.googlecode.lanterna.input.Key$Kind/ReverseTab :reverse-tab
-   com.googlecode.lanterna.input.Key$Kind/Enter :enter
-   com.googlecode.lanterna.input.Key$Kind/Unknown :unknown
-   com.googlecode.lanterna.input.Key$Kind/CursorLocation :cursor-location})
+  {;; KeyType/NormalKey :normal
+   KeyType/Escape :escape
+   KeyType/Backspace :backspace
+   KeyType/ArrowLeft :left
+   KeyType/ArrowRight :right
+   KeyType/ArrowUp :up
+   KeyType/ArrowDown :down
+   KeyType/Insert :insert
+   KeyType/Delete :delete
+   KeyType/Home :home
+   KeyType/End :end
+   KeyType/PageUp :page-up
+   KeyType/PageDown :page-down
+   KeyType/Tab :tab
+   KeyType/ReverseTab :reverse-tab
+   KeyType/Enter :enter
+   KeyType/Unknown :unknown
+   KeyType/CursorLocation :cursor-location})
 
+;; (def palettes
+;;   {:gnome      TerminalPalette/GNOME_TERMINAL
+;;    :vga        TerminalPalette/STANDARD_VGA
+;;    :windows-xp TerminalPalette/WINDOWS_XP_COMMAND_PROMPT
+;;    :mac-os-x   TerminalPalette/MAC_OS_X_TERMINAL_APP
+;;    :xterm      TerminalPalette/PUTTY
+;;    :putty      TerminalPalette/XTERM})
 
-(def palettes
-  {:gnome      TerminalPalette/GNOME_TERMINAL
-   :vga        TerminalPalette/STANDARD_VGA
-   :windows-xp TerminalPalette/WINDOWS_XP_COMMAND_PROMPT
-   :mac-os-x   TerminalPalette/MAC_OS_X_TERMINAL_APP
-   :xterm      TerminalPalette/PUTTY
-   :putty      TerminalPalette/XTERM})
+;; (def enter-styles
+;;   {:bold com.googlecode.lanterna.terminal.Terminal$SGR/ENTER_BOLD
+;;    :reverse com.googlecode.lanterna.terminal.Terminal$SGR/ENTER_REVERSE
+;;    :blinking com.googlecode.lanterna.terminal.Terminal$SGR/ENTER_BLINK
+;;    :underline com.googlecode.lanterna.terminal.Terminal$SGR/ENTER_UNDERLINE})
 
-(def enter-styles
-  {:bold com.googlecode.lanterna.terminal.Terminal$SGR/ENTER_BOLD
-   :reverse com.googlecode.lanterna.terminal.Terminal$SGR/ENTER_REVERSE
-   :blinking com.googlecode.lanterna.terminal.Terminal$SGR/ENTER_BLINK
-   :underline com.googlecode.lanterna.terminal.Terminal$SGR/ENTER_UNDERLINE})
+;; (def exit-styles
+;;   {:bold com.googlecode.lanterna.terminal.Terminal$SGR/EXIT_BOLD
+;;    :reverse com.googlecode.lanterna.terminal.Terminal$SGR/EXIT_REVERSE
+;;    :blinking com.googlecode.lanterna.terminal.Terminal$SGR/EXIT_BLINK
+;;    :underline com.googlecode.lanterna.terminal.Terminal$SGR/EXIT_UNDERLINE})
 
-(def exit-styles
-  {:bold com.googlecode.lanterna.terminal.Terminal$SGR/EXIT_BOLD
-   :reverse com.googlecode.lanterna.terminal.Terminal$SGR/EXIT_REVERSE
-   :blinking com.googlecode.lanterna.terminal.Terminal$SGR/EXIT_BLINK
-   :underline com.googlecode.lanterna.terminal.Terminal$SGR/EXIT_UNDERLINE})
-
-(def reset-style
-  com.googlecode.lanterna.terminal.Terminal$SGR/RESET_ALL)
+;; (def reset-style
+;;   com.googlecode.lanterna.terminal.Terminal$SGR/RESET_ALL)

--- a/src/lanterna/constants.clj
+++ b/src/lanterna/constants.clj
@@ -1,10 +1,8 @@
 (ns lanterna.constants
-  (:import java.nio.charset.Charset
-           com.googlecode.lanterna.input.KeyType
+  (:import com.googlecode.lanterna.SGR
            com.googlecode.lanterna.TextColor$ANSI
-           com.googlecode.lanterna.SGR
-           ;; com.googlecode.lanterna.terminal.swing.TerminalPalette
-           ))
+           com.googlecode.lanterna.input.KeyType
+           java.nio.charset.Charset))
 
 (def charsets {:utf-8 (Charset/forName "UTF-8")})
 
@@ -45,25 +43,8 @@
    KeyType/Unknown :unknown
    KeyType/CursorLocation :cursor-location})
 
-;; (def palettes
-;;   {:gnome      TerminalPalette/GNOME_TERMINAL
-;;    :vga        TerminalPalette/STANDARD_VGA
-;;    :windows-xp TerminalPalette/WINDOWS_XP_COMMAND_PROMPT
-;;    :mac-os-x   TerminalPalette/MAC_OS_X_TERMINAL_APP
-;;    :xterm      TerminalPalette/PUTTY
-;;    :putty      TerminalPalette/XTERM})
-
-;; (def enter-styles
-;;   {:bold com.googlecode.lanterna.terminal.Terminal$SGR/ENTER_BOLD
-;;    :reverse com.googlecode.lanterna.terminal.Terminal$SGR/ENTER_REVERSE
-;;    :blinking com.googlecode.lanterna.terminal.Terminal$SGR/ENTER_BLINK
-;;    :underline com.googlecode.lanterna.terminal.Terminal$SGR/ENTER_UNDERLINE})
-
-;; (def exit-styles
-;;   {:bold com.googlecode.lanterna.terminal.Terminal$SGR/EXIT_BOLD
-;;    :reverse com.googlecode.lanterna.terminal.Terminal$SGR/EXIT_REVERSE
-;;    :blinking com.googlecode.lanterna.terminal.Terminal$SGR/EXIT_BLINK
-;;    :underline com.googlecode.lanterna.terminal.Terminal$SGR/EXIT_UNDERLINE})
-
-;; (def reset-style
-;;   com.googlecode.lanterna.terminal.Terminal$SGR/RESET_ALL)
+(def sgr
+  {:bold com.googlecode.lanterna.SGR/BOLD
+   :reverse com.googlecode.lanterna.SGR/REVERSE
+   :blinking com.googlecode.lanterna.SGR/BLINK
+   :underline com.googlecode.lanterna.SGR/UNDERLINE})

--- a/src/lanterna/screen.clj
+++ b/src/lanterna/screen.clj
@@ -1,81 +1,88 @@
 (ns lanterna.screen
-  (:import com.googlecode.lanterna.screen.Screen
-           com.googlecode.lanterna.terminal.Terminal)
-  (:use [lanterna.common :only [parse-key block-on]])
-  (:require [lanterna.constants :as c]
-            [lanterna.terminal :as t]))
+  (:import
+   com.googlecode.lanterna.screen.Screen
+   com.googlecode.lanterna.terminal.Terminal
+   com.googlecode.lanterna.screen.TerminalScreen)
+  (:require
+   [lanterna.common :refer [parse-key block-on]]
+   [lanterna.constants :as c]
+   [lanterna.terminal :as t]))
 
+(defn ^Screen terminal-screen
+  ""
+  [^Terminal terminal]
+  (TerminalScreen. terminal))
 
 (defn enumerate [s]
   (map vector (iterate inc 0) s))
 
-(defn add-resize-listener
-  "Create a listener that will call the supplied fn when the screen is resized.
+;; (defn add-resize-listener
+;;   "Create a listener that will call the supplied fn when the screen is resized.
 
-  The function must take two arguments: the new number of columns and the new
-  number of rows.
+;;   The function must take two arguments: the new number of columns and the new
+;;   number of rows.
 
-  The listener itself will be returned.  You don't need to do anything with it,
-  but you can use it to remove it later with remove-resize-listener.
+;;   The listener itself will be returned.  You don't need to do anything with it,
+;;   but you can use it to remove it later with remove-resize-listener.
 
-  "
-  [^Screen screen listener-fn]
-  (t/add-resize-listener (.getTerminal screen)
-                         listener-fn))
+;;   "
+;;   [^Screen screen listener-fn]
+;;   (t/add-resize-listener (.getTerminal screen)
+;;                          listener-fn))
 
-(defn remove-resize-listener
-  "Remove a resize listener from the given screen."
-  [^Screen screen listener]
-  (t/remove-resize-listener (.getTerminal screen) listener))
+;; (defn remove-resize-listener
+;;   "Remove a resize listener from the given screen."
+;;   [^Screen screen listener]
+;;   (t/remove-resize-listener (.getTerminal screen) listener))
 
-(defn get-screen
-  "Get a screen object.
+;; (defn get-screen
+;;   "Get a screen object.
 
-  kind can be one of the following:
+;;   kind can be one of the following:
 
-  :auto   - Try to guess the right type of screen based on OS, whether
-            there's a windowing environment, etc
-  :swing  - Force a Swing-based screen.
-  :text   - Force a console (i.e.: non-Swing) screen.  Try to guess the
-            appropriate kind of console (UNIX/Cygwin) by the OS.
-  :unix   - Force a UNIX console screen.
-  :cygwin - Force a Cygwin console screen.
+;;   :auto   - Try to guess the right type of screen based on OS, whether
+;;             there's a windowing environment, etc
+;;   :swing  - Force a Swing-based screen.
+;;   :text   - Force a console (i.e.: non-Swing) screen.  Try to guess the
+;;             appropriate kind of console (UNIX/Cygwin) by the OS.
+;;   :unix   - Force a UNIX console screen.
+;;   :cygwin - Force a Cygwin console screen.
 
-  Options can contain one or more of the following keys:
+;;   Options can contain one or more of the following keys:
 
-  :cols    - Width of the desired screen in characters (default 80).
-  :rows    - Height of the desired screen in characters (default 24).
-  :charset - Charset of the desired screen.  Can be any of
-             (keys lanterna.constants/charsets) (default :utf-8).
-  :resize-listener - A function to call when the screen is resized.  This
-                     function should take two parameters: the new number of
-                     columns, and the new number of rows.
-  :font      - Font to use.  String or sequence of strings.
-               Use (lanterna.terminal/get-available-fonts) to see your options.
-               Will fall back to a basic monospaced font if none of the given
-               names are available.
-  :font-size - An int of the size of the font to use.
+;;   :cols    - Width of the desired screen in characters (default 80).
+;;   :rows    - Height of the desired screen in characters (default 24).
+;;   :charset - Charset of the desired screen.  Can be any of
+;;              (keys lanterna.constants/charsets) (default :utf-8).
+;;   :resize-listener - A function to call when the screen is resized.  This
+;;                      function should take two parameters: the new number of
+;;                      columns, and the new number of rows.
+;;   :font      - Font to use.  String or sequence of strings.
+;;                Use (lanterna.terminal/get-available-fonts) to see your options.
+;;                Will fall back to a basic monospaced font if none of the given
+;;                names are available.
+;;   :font-size - An int of the size of the font to use.
 
-  NOTE: The options are really just a suggestion!
+;;   NOTE: The options are really just a suggestion!
 
-  The console screen will ignore rows and columns and will be the size of the
-  user's window.
+;;   The console screen will ignore rows and columns and will be the size of the
+;;   user's window.
 
-  The Swing screen will start out at this size but can be resized later by the
-  user, and will ignore the charset entirely.
+;;   The Swing screen will start out at this size but can be resized later by the
+;;   user, and will ignore the charset entirely.
 
-  God only know what Cygwin will do.
+;;   God only know what Cygwin will do.
 
-  "
-  ([] (get-screen :auto {}))
-  ([kind] (get-screen kind {}))
-  ([kind {:as opts
-          :keys [cols rows charset resize-listener]
-          :or {cols 80
-               rows 24
-               charset :utf-8
-               resize-listener nil}}]
-   (new Screen (t/get-terminal kind opts))))
+;;   "
+;;   ([] (get-screen :auto {}))
+;;   ([kind] (get-screen kind {}))
+;;   ([kind {:as opts
+;;           :keys [cols rows charset resize-listener]
+;;           :or {cols 80
+;;                rows 24
+;;                charset :utf-8
+;;                resize-listener nil}}]
+;;    (new Screen (t/get-terminal kind opts))))
 
 
 (defn start
@@ -301,17 +308,17 @@
      (block-on get-key [screen] opts)))
 
 
-(comment
-  (def s (get-screen))
-  (start s)
+;; ;; (comment
+;; ;;   (def s (get-screen))
+;; ;;   (start s)
 
-  (put-sheet s 5 5 ["foo" "bar" "hello"])
-  (put-sheet s 5 9 [[\f \o \o] ["b" "a" "r"] "hello"])
-  (let [r [\r {:bg :red :fg :white}]
-        g [\g {:bg :green :fg :black}]
-        b [\b {:bg :blue :fg :white}]]
-    (put-sheet s 5 13 [[r r r] [g g g] [b b b]]))
+;; ;;   (put-sheet s 5 5 ["foo" "bar" "hello"])
+;; ;;   (put-sheet s 5 9 [[\f \o \o] ["b" "a" "r"] "hello"])
+;; ;;   (let [r [\r {:bg :red :fg :white}]
+;; ;;         g [\g {:bg :green :fg :black}]
+;; ;;         b [\b {:bg :blue :fg :white}]]
+;; ;;     (put-sheet s 5 13 [[r r r] [g g g] [b b b]]))
 
-  (redraw s)
-  (stop s)
-  )
+;; ;;   (redraw s)
+;; ;;   (stop s)
+;; ;;   )

--- a/src/lanterna/screen.clj
+++ b/src/lanterna/screen.clj
@@ -8,82 +8,30 @@
    [lanterna.constants :as c]
    [lanterna.terminal :as t]))
 
-(defn ^Screen terminal-screen
-  ""
-  [^Terminal terminal]
-  (TerminalScreen. terminal))
-
-(defn enumerate [s]
+(defn- enumerate [s]
   (map vector (iterate inc 0) s))
 
-;; (defn add-resize-listener
-;;   "Create a listener that will call the supplied fn when the screen is resized.
+(defn ^Screen terminal-screen [^Terminal terminal]
+  (TerminalScreen. terminal))
 
-;;   The function must take two arguments: the new number of columns and the new
-;;   number of rows.
+(defn add-resize-listener
+  "Create a listener that will call the supplied fn when the screen is resized.
 
-;;   The listener itself will be returned.  You don't need to do anything with it,
-;;   but you can use it to remove it later with remove-resize-listener.
+  The function must take two arguments: the new number of columns and the new
+  number of rows.
 
-;;   "
-;;   [^Screen screen listener-fn]
-;;   (t/add-resize-listener (.getTerminal screen)
-;;                          listener-fn))
+  The listener itself will be returned.  You don't need to do anything with it,
+  but you can use it to remove it later with remove-resize-listener.
 
-;; (defn remove-resize-listener
-;;   "Remove a resize listener from the given screen."
-;;   [^Screen screen listener]
-;;   (t/remove-resize-listener (.getTerminal screen) listener))
+  "
+  [^Screen screen listener-fn]
+  (t/add-resize-listener (.getTerminal screen)
+                         listener-fn))
 
-;; (defn get-screen
-;;   "Get a screen object.
-
-;;   kind can be one of the following:
-
-;;   :auto   - Try to guess the right type of screen based on OS, whether
-;;             there's a windowing environment, etc
-;;   :swing  - Force a Swing-based screen.
-;;   :text   - Force a console (i.e.: non-Swing) screen.  Try to guess the
-;;             appropriate kind of console (UNIX/Cygwin) by the OS.
-;;   :unix   - Force a UNIX console screen.
-;;   :cygwin - Force a Cygwin console screen.
-
-;;   Options can contain one or more of the following keys:
-
-;;   :cols    - Width of the desired screen in characters (default 80).
-;;   :rows    - Height of the desired screen in characters (default 24).
-;;   :charset - Charset of the desired screen.  Can be any of
-;;              (keys lanterna.constants/charsets) (default :utf-8).
-;;   :resize-listener - A function to call when the screen is resized.  This
-;;                      function should take two parameters: the new number of
-;;                      columns, and the new number of rows.
-;;   :font      - Font to use.  String or sequence of strings.
-;;                Use (lanterna.terminal/get-available-fonts) to see your options.
-;;                Will fall back to a basic monospaced font if none of the given
-;;                names are available.
-;;   :font-size - An int of the size of the font to use.
-
-;;   NOTE: The options are really just a suggestion!
-
-;;   The console screen will ignore rows and columns and will be the size of the
-;;   user's window.
-
-;;   The Swing screen will start out at this size but can be resized later by the
-;;   user, and will ignore the charset entirely.
-
-;;   God only know what Cygwin will do.
-
-;;   "
-;;   ([] (get-screen :auto {}))
-;;   ([kind] (get-screen kind {}))
-;;   ([kind {:as opts
-;;           :keys [cols rows charset resize-listener]
-;;           :or {cols 80
-;;                rows 24
-;;                charset :utf-8
-;;                resize-listener nil}}]
-;;    (new Screen (t/get-terminal kind opts))))
-
+(defn remove-resize-listener
+  "Remove a resize listener from the given screen."
+  [^Screen screen listener]
+  (t/remove-resize-listener (.getTerminal screen) listener))
 
 (defn start
   "Start the screen.  Consider using in-screen instead.
@@ -306,19 +254,3 @@
   ([^Screen screen] (get-key-blocking screen {}))
   ([^Screen screen {:keys [interval timeout] :as opts}]
      (block-on get-key [screen] opts)))
-
-
-;; ;; (comment
-;; ;;   (def s (get-screen))
-;; ;;   (start s)
-
-;; ;;   (put-sheet s 5 5 ["foo" "bar" "hello"])
-;; ;;   (put-sheet s 5 9 [[\f \o \o] ["b" "a" "r"] "hello"])
-;; ;;   (let [r [\r {:bg :red :fg :white}]
-;; ;;         g [\g {:bg :green :fg :black}]
-;; ;;         b [\b {:bg :blue :fg :white}]]
-;; ;;     (put-sheet s 5 13 [[r r r] [g g g] [b b b]]))
-
-;; ;;   (redraw s)
-;; ;;   (stop s)
-;; ;;   )

--- a/src/lanterna/terminal.clj
+++ b/src/lanterna/terminal.clj
@@ -1,124 +1,75 @@
 (ns lanterna.terminal
-  (:import com.googlecode.lanterna.TerminalFacade
-           com.googlecode.lanterna.terminal.Terminal
-           com.googlecode.lanterna.terminal.swing.SwingTerminal
-           com.googlecode.lanterna.terminal.swing.TerminalAppearance
-           com.googlecode.lanterna.terminal.swing.TerminalPalette
-           java.awt.GraphicsEnvironment
-           java.awt.Font)
-  (:use [lanterna.common :only [parse-key block-on]])
-  (:require [lanterna.constants :as c]))
+  (:refer-clojure :exclude [flush])
+  (:import
+   com.googlecode.lanterna.TerminalPosition
+   com.googlecode.lanterna.terminal.Terminal
+   com.googlecode.lanterna.terminal.ansi.UnixTerminal
+   com.googlecode.lanterna.terminal.ansi.CygwinTerminal
+   ;; com.googlecode.lanterna.terminal.swing.SwingTerminal
+   ;; com.googlecode.lanterna.terminal.swing.TerminalAppearance
+   ;; java.awt.Font
+   ;; java.awt.GraphicsEnvironment
+   )
+  (:require
+   [lanterna.common :refer [parse-key block-on]]
+   [lanterna.constants :as c]))
+
+;; (defn add-resize-listener
+;;   "Create a listener that will call the supplied fn when the terminal is resized.
+
+;;   The function must take two arguments: the new number of columns and the new
+;;   number of rows.
+
+;;   The listener itself will be returned.  You don't need to do anything with it,
+;;   but you can use it to remove it later with remove-resize-listener.
+
+;;   "
+;;   [^Terminal terminal listener-fn]
+;;   (let [listener (reify com.googlecode.lanterna.terminal.Terminal$ResizeListener
+;;                    (onResized [this newSize]
+;;                      (listener-fn (.getColumns newSize)
+;;                                   (.getRows newSize))))]
+;;     (.addResizeListener terminal listener)
+;;     listener))
+
+;; (defn remove-resize-listener
+;;   "Remove a resize listener from the given terminal."
+;;   [^Terminal terminal listener]
+;;   (.removeResizeListener terminal listener))
+
+;; (defn get-available-fonts []
+;;   (set (.getAvailableFontFamilyNames
+;;          (GraphicsEnvironment/getLocalGraphicsEnvironment))))
+
+;; (defn- get-font-name [font]
+;;   (let [fonts (if (coll? font) font [font])
+;;         fonts (concat fonts ["Monospaced"])
+;;         available (get-available-fonts)]
+;;     (first (filter available fonts))))
 
 
+;; (defn- get-swing-terminal [cols rows
+;;                            {:as opts
+;;                             :keys [font font-size palette]
+;;                             :or {font ["Menlo" "Consolas" "Monospaced"]
+;;                                  font-size 14
+;;                                  palette :mac-os-x}}]
+;;   (let [font (get-font-name font)
+;;         appearance (new TerminalAppearance
+;;                         (new Font font Font/PLAIN font-size)
+;;                         (new Font font Font/BOLD font-size)
+;;                         (c/palettes palette) true)]
+;;     (new SwingTerminal appearance cols rows)))
 
-(defn add-resize-listener
-  "Create a listener that will call the supplied fn when the terminal is resized.
+(defn windows? []
+  (-> (System/getProperty "os.name" "")
+      (.toLowerCase)
+      (.startsWith "windows")))
 
-  The function must take two arguments: the new number of columns and the new
-  number of rows.
-
-  The listener itself will be returned.  You don't need to do anything with it,
-  but you can use it to remove it later with remove-resize-listener.
-
-  "
-  [^Terminal terminal listener-fn]
-  (let [listener (reify com.googlecode.lanterna.terminal.Terminal$ResizeListener
-                   (onResized [this newSize]
-                     (listener-fn (.getColumns newSize)
-                                  (.getRows newSize))))]
-    (.addResizeListener terminal listener)
-    listener))
-
-(defn remove-resize-listener
-  "Remove a resize listener from the given terminal."
-  [^Terminal terminal listener]
-  (.removeResizeListener terminal listener))
-
-(defn get-available-fonts []
-  (set (.getAvailableFontFamilyNames
-         (GraphicsEnvironment/getLocalGraphicsEnvironment))))
-
-(defn- get-font-name [font]
-  (let [fonts (if (coll? font) font [font])
-        fonts (concat fonts ["Monospaced"])
-        available (get-available-fonts)]
-    (first (filter available fonts))))
-
-
-(defn- get-swing-terminal [cols rows
-                           {:as opts
-                            :keys [font font-size palette]
-                            :or {font ["Menlo" "Consolas" "Monospaced"]
-                                 font-size 14
-                                 palette :mac-os-x}}]
-  (let [font (get-font-name font)
-        appearance (new TerminalAppearance
-                        (new Font font Font/PLAIN font-size)
-                        (new Font font Font/BOLD font-size)
-                        (c/palettes palette) true)]
-    (new SwingTerminal appearance cols rows)))
-
-(defn get-terminal
-  "Get a terminal object.
-
-  kind can be one of the following:
-
-  :auto   - Try to guess the right type of terminal based on OS, whether
-            there's a windowing environment, etc
-  :swing  - Force a Swing-based terminal.
-  :text   - Force a console (i.e.: non-Swing) terminal.  Try to guess the
-            appropriate kind of console (UNIX/Cygwin) by the OS.
-  :unix   - Force a UNIX console terminal.
-  :cygwin - Force a Cygwin console terminal.
-
-  Options can contain one or more of the following keys:
-
-  :cols    - Width of the desired terminal in characters (default 80).
-  :rows    - Height of the desired terminal in characters (default 24).
-  :charset - Charset of the desired terminal.  Can be any of
-             (keys lanterna.constants/charsets) (default :utf-8).
-  :resize-listener - A function to call when the terminal is resized.  This
-                     function should take two parameters: the new number of
-                     columns, and the new number of rows.
-  :font      - Font to use.  String or sequence of strings.
-               Use (lanterna.terminal/get-available-fonts) to see your options.
-               Will fall back to a basic monospaced font if none of the given
-               names are available.
-  :font-size - Font size (default 14).
-  :palette   - Color palette to use. Can be any of
-               (keys lanterna.constants/palettes) (default :mac-os-x).
-
-  NOTE: The options are really just a suggestion!
-
-  The console terminal will ignore rows and columns and fonts and colors.
-
-  The Swing terminal will start out at this size but can be resized later by the
-  user, and will ignore the charset entirely.
-
-  God only know what Cygwin will do.
-
-  "
-  ([] (get-terminal :auto {}))
-  ([kind] (get-terminal kind {}))
-  ([kind {:as opts
-          :keys [cols rows charset resize-listener]
-          :or {cols 80
-               rows 24
-               charset :utf-8
-               resize-listener nil}}]
-   (let [in System/in
-         out System/out
-         charset (c/charsets charset)
-         terminal (case kind
-                    :auto   (TerminalFacade/createTerminal charset)
-                    :swing  (get-swing-terminal cols rows opts)
-                    :text   (TerminalFacade/createTextTerminal in out charset)
-                    :unix   (TerminalFacade/createUnixTerminal in out charset)
-                    :cygwin (TerminalFacade/createCygwinTerminal in out charset))]
-     (when resize-listener
-       (add-resize-listener terminal resize-listener))
-     terminal)))
-
+(defn text-terminal []
+  (if (windows?)
+    (new CygwinTerminal System/in System/out (java.nio.charset.Charset/forName "UTF8"))
+    (new UnixTerminal System/in System/out (java.nio.charset.Charset/forName "UTF8"))))
 
 (defn start
   "Start the terminal.  Consider using in-terminal instead."
@@ -169,21 +120,20 @@
    (move-cursor terminal x y)
    (put-character terminal ch)))
 
+
 (defn put-string
-  "Draw the string at the current cursor location.
-
-  If x and y are given, moves the cursor there first.
-
-  The cursor will end up at the position directly after the string.
-
-  "
-  ([^Terminal terminal s]
-   (dorun (map (partial put-character terminal)
-               s)))
-  ([terminal s x y]
-   (move-cursor terminal x y)
-   (put-string terminal s)))
-
+  ([^Terminal terminal ^String s]
+   (let [position ^TerminalPosition (.getPosition terminal)]
+     (put-string terminal s (.getColumn position) (.getRow position))))
+  ([^Terminal terminal ^String s ^Integer column ^Integer row]
+   (doall
+    (reduce (fn [acc c]
+              (.setCursorPosition terminal (:column acc) (:row acc))
+              (.putCharacter terminal c)
+              (update acc :column inc))
+            {:column column :row row}
+            s))
+   nil))
 
 (defn clear
   "Clear the terminal.
@@ -194,6 +144,11 @@
   [^Terminal terminal]
   (.clearScreen terminal)
   (move-cursor terminal 0 0))
+
+(defn flush
+  ""
+  [^Terminal terminal]
+  (.flush terminal))
 
 
 (defn set-fg-color [^Terminal terminal color]
@@ -252,18 +207,16 @@
      (block-on get-key [terminal] opts)))
 
 
-(comment
+;; (comment
 
-  (def t (get-terminal :swing
-                       {:cols 40 :rows 30
-                        :font ["Menlo"]
-                        :font-size 24
-                        :palette :gnome}))
-  (start t)
-  (set-fg-color t :yellow)
-  (put-string t "Hello, world!")
-  (get-key-blocking t {:timeout 1000})
-  (get-key-blocking t {:interval 2000})
-  (stop t)
-
-  )
+;;   (def t (get-terminal :swing
+;;                        {:cols 40 :rows 30
+;;                         :font ["Menlo"]
+;;                         :font-size 24
+;;                         :palette :gnome}))
+;;   (start t)
+;;   (set-fg-color t :yellow)
+;;   (put-string t "Hello, world!")
+;;   (get-key-blocking t {:timeout 1000})
+;;   (get-key-blocking t {:interval 2000})
+;;   (stop t))


### PR DESCRIPTION
Most notable: Replaced `get-terminal` with `text-terminal`.

Still need to look at a few things that have changes in lanterna. I've commented those out to make it compile.

This works in `bb`:

```clojure
(require '[lanterna.terminal :as terminal])

(def terminal (terminal/text-terminal))

(terminal/start terminal)
(terminal/put-string terminal "Hello TUI Babashka!" 10 5)
(terminal/flush terminal)

(Thread/sleep 1000)
```