### PR TITLE
Enable advanced color modes in screen/put-string

### DIFF
--- a/src/lanterna/screen.clj
+++ b/src/lanterna/screen.clj
@@ -123,12 +123,24 @@
   Options can contain any of the following:
 
   :fg - Foreground color.
-  Can be any one of (keys lanterna.constants/colors).
-  (default :default)
+   This can be either a keyword or a string.
+   If it's a keyword, it should be one of (keys lanterna.constants/colors).
+   Not all terminals support all colormodes, you can consult lanterna's 
+   [TextColor documentaion](https://mabe02.github.io/lanterna/apidocs/3.1/com/googlecode/lanterna/TextColor.html)
+   to learn more.
+   If it is a string, it must be in one of the following formats.
+
+   * \"blue\", a string matching a color constant.
+   * \"#1 \", a string consisting of an int between 0 and 255.
+     This will use the indexed colormode, looking up the color in the terminal's own theme.
+   * \"#a1a1a1\", a hex color code in a string. This draws using the color provided in RGB mode..
+
+   As an escape hatch, directly providing a TextColor will use that to draw instead.
+   an unparseable input will draw with (lanterna.constants/colors :default) or error.
+
 
   :bg - Background color.
-  Can be any one of (keys lanterna.constants/colors).
-  (default :default)
+  The same options for :fg, but will apply to the background instead.
 
   :styles - Styles to apply to the text.
   Can be a set containing some/none/all of (keys lanterna.constants/styles).
@@ -145,8 +157,8 @@
          (into-array SGR (map c/styles styles))
          col (int col)
          row (int row)
-         fg ^TextColor (c/colors fg)
-         bg ^TextColor (c/colors bg)]
+         fg  (t/parse-color fg)
+         bg  (t/parse-color bg)]
      (reduce (fn [acc ^java.lang.Character c]
                (let [col (:col acc)
                      row (:row acc)

--- a/src/lanterna/terminal.clj
+++ b/src/lanterna/terminal.clj
@@ -6,7 +6,8 @@
    com.googlecode.lanterna.terminal.Terminal
    com.googlecode.lanterna.terminal.TerminalResizeListener
    com.googlecode.lanterna.terminal.ansi.UnixTerminal
-   com.googlecode.lanterna.terminal.ansi.CygwinTerminal)
+   com.googlecode.lanterna.terminal.ansi.CygwinTerminal
+   com.googlecode.lanterna.TextColor)
   (:require
    [lanterna.common :refer [parse-key block-on]]
    [lanterna.constants :as c]))
@@ -137,6 +138,27 @@
   [^Terminal terminal]
   (.flush terminal))
 
+(defn parse-color ^TextColor
+  "Takes a keyword, a string, or a TextColor, and returns a TextColor.
+   For keyword, it looks it up in lanterna.constants/colors.
+   For a string, it parses it using the underlying java implementation.
+   For a text color, it returns it unchanged.
+   
+   Returns (lanterna.constants/colors :default) or errors.
+   "
+  [inp-color]
+  (cond
+    (instance? TextColor inp-color)
+    inp-color
+
+    (keyword? inp-color)
+    (c/colors inp-color)
+
+    (string? inp-color)
+    (com.googlecode.lanterna.TextColor$Factory/fromString inp-color)
+
+    :else
+    (c/colors :default)))
 
 (defn set-fg-color [^Terminal terminal color]
   (.setForegroundColor terminal (c/colors color)))


### PR DESCRIPTION
### Reasoning
I'm poking around roguelike design in clojure, using clojure-lanterna. I wanted to specify the RGB colors drawn, and use more advanced features in the underlying library.

### Features
* No API changes for people consuming the library correctly.
* Indexed mode accessible.
* RGB mode accessible.
* Mostly delegates to the wrapped library, so maintenance should be minimal.

### Implementation
I have a few questions relating to implementation I'd like to see before this is merged.

1. Is the Markdown in the docstring acceptable? I personally feel it helps with readability, but I'm not a maintainer here.
2. Given `put-string` is likely to be called a lot, I'm considering adding a core.cache to it, so that we aren't parsing the same string over and over in a hot loop. (This was partially why I setup the TextColor passthrough,  to allow users to optimize.) I have no benchmarks, but it is a concern. I also considered a protocol, to allow for faster dispatch, but that felt heavyhanded for a first go.
3. Most of the library doesn't seem to get in the way of any underlying java errors, but providing a bad string now gives a two layered exception, first an `IllegalArgumentException`, then an error from trying to type-hint the first exception. Between that and the exception making the default return of `TextColor$ANSI/DEFAULT` no longer guaranteed, it makes me wonder if I should catch and suppress the error.